### PR TITLE
refactor: separate Kafka consumers from web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ After the containers are up and running, execute the migration inside the runnin
 docker exec go-ecommerce make migrate
 ```
 
+### 4. Running Kafka Consumers
+
+Kafka consumers run as a separate process that listens for events and updates the database. Start them with:
+
+```sh
+go run cmd/consumer/main.go
+```
+
 ## Available Endpoints
 
 ### Authentication
@@ -90,7 +98,7 @@ docker exec go-ecommerce make migrate
 
 ## Kafka Integration
 
-The application utilizes Kafka for asynchronous processing of order-related tasks. This allows for better scalability and responsiveness, as order processing can occur in the background without blocking the main application flow.
+The application utilizes Kafka for asynchronous processing of order-related tasks. Kafka consumers run in a separate service, allowing them to listen for messages and handle background work without blocking the main API.
 
 ## Swagger Documentation
 

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/abdisetiakawan/go-ecommerce/internal/config"
+)
+
+func main() {
+	viperConfig := config.NewViper()
+	logger := config.NewLogger(viperConfig)
+	db := config.NewDatabase(viperConfig, logger)
+
+	consumers, err := config.BootstrapConsumers(&config.ConsumerBootstrapConfig{
+		DB:     db,
+		Config: viperConfig,
+	})
+	if err != nil {
+		logger.Fatal(err)
+		panic(err)
+	}
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	<-quit
+	logger.Info("Shutting down consumer...")
+
+	for _, c := range consumers {
+		if err := c.Close(); err != nil {
+			logger.Error(err)
+		}
+	}
+	logger.Info("Consumer stopped")
+}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -20,109 +20,88 @@ import (
 var swaggerYAML []byte
 
 func main() {
-    viperConfig := config.NewViper()
+	viperConfig := config.NewViper()
 
-    logger := config.NewLogger(viperConfig)
-    db := config.NewDatabase(viperConfig, logger)
-    validator := config.NewValidator()
-    jwt := helper.NewJWTHelper(viperConfig)
-    uuid := helper.NewUUIDHelper()
+	logger := config.NewLogger(viperConfig)
+	db := config.NewDatabase(viperConfig, logger)
+	validator := config.NewValidator()
+	jwt := helper.NewJWTHelper(viperConfig)
+	uuid := helper.NewUUIDHelper()
 
-    kafkaProducer, err := helper.NewKafkaProducer(viperConfig)
-    if err != nil {
-        logger.Fatal(err)
-        panic(err)
-    }
-    paymentConsumer, err := helper.NewKafkaConsumer(viperConfig, "payment-consumer")
-    if err != nil {
-        logger.Fatal(err)
-        panic(err)
-    }
+	kafkaProducer, err := helper.NewKafkaProducer(viperConfig)
+	if err != nil {
+		logger.Fatal(err)
+		panic(err)
+	}
 
-    shippingConsumer, err := helper.NewKafkaConsumer(viperConfig, "shipping-consumer")
-    if err != nil {
-        logger.Fatal(err)
-        panic(err)
-    }
+	app := config.NewFiber(viperConfig)
+	app.Use(cors.New(cors.Config{
+		AllowOrigins:     "http://localhost:5173",
+		AllowCredentials: true,
+		AllowMethods:     "GET,POST,HEAD,PUT,DELETE,PATCH",
+		AllowHeaders:     "Origin, Content-Type, Accept, Authorization",
+		ExposeHeaders:    "Content-Length",
+		MaxAge:           3600,
+	}))
+	app.Get("/swagger.yaml", func(c *fiber.Ctx) error {
+		c.Set("Content-Type", "text/yaml")
+		return c.Send(swaggerYAML)
+	})
 
-    orderConsumer, err := helper.NewKafkaConsumer(viperConfig, "order-consumer")
-    if err != nil {
-        logger.Fatal(err)
-        panic(err)
-    }
+	app.Get("/swagger/*", swagger.New(swagger.Config{
+		URL: "/swagger.yaml",
+	}))
 
-    app := config.NewFiber(viperConfig)
-    app.Use(cors.New(cors.Config{
-        AllowOrigins: "http://localhost:5173",
-        AllowCredentials: true,
-        AllowMethods: "GET,POST,HEAD,PUT,DELETE,PATCH",
-        AllowHeaders: "Origin, Content-Type, Accept, Authorization",
-        ExposeHeaders: "Content-Length",
-        MaxAge: 3600,
-    }))
-    app.Get("/swagger.yaml", func(c *fiber.Ctx) error {
-        c.Set("Content-Type", "text/yaml")
-        return c.Send(swaggerYAML)
-    })
+	config.Bootstrap(&config.BootstrapConfig{DB: db, App: app, Validate: validator, Config: viperConfig, Jwt: jwt, UserUUID: uuid, KafkaProducer: kafkaProducer})
+	port := viperConfig.GetInt("PORT")
+	logger.Infof("Starting server on port %d", port)
 
-    app.Get("/swagger/*", swagger.New(swagger.Config{
-        URL: "/swagger.yaml",
-    }))
+	// Graceful shutdown
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
 
-    config.Bootstrap(&config.BootstrapConfig{DB: db, App: app, Validate: validator, Config: viperConfig, Jwt: jwt, UserUUID: uuid, KafkaProducer: kafkaProducer,  PaymentConsumer: paymentConsumer, ShippingConsumer: shippingConsumer, OrderConsumer: orderConsumer})
-    port := viperConfig.GetInt("PORT")
-    logger.Infof("Starting server on port %d", port)
+	go func() {
+		<-quit
+		logger.Info("Shutting down server...")
 
-    // Graceful shutdown
-    quit := make(chan os.Signal, 1)
-    signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+		// Create context with timeout for graceful shutdown
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-    go func() {
-        <-quit
-        logger.Info("Shutting down server...")
-        
-        // Create context with timeout for graceful shutdown
-        ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-        defer cancel()
+		// Create error channel to collect shutdown errors
+		shutdownErrors := make(chan error, 2)
 
-        // Create error channel to collect shutdown errors
-        shutdownErrors := make(chan error, 5)
-        
-        // Shutdown components concurrently
-        go func() { shutdownErrors <- app.Shutdown() }()
-        go func() { shutdownErrors <- kafkaProducer.Close() }()
-        go func() { shutdownErrors <- paymentConsumer.Close() }()
-        go func() { shutdownErrors <- shippingConsumer.Close() }()
-        go func() { shutdownErrors <- orderConsumer.Close() }()
-    
+		// Shutdown components concurrently
+		go func() { shutdownErrors <- app.Shutdown() }()
+		go func() { shutdownErrors <- kafkaProducer.Close() }()
 
-        // Collect shutdown errors
-        var shutdownError error
-        for i := 0; i < 5; i++ {
-            if err := <-shutdownErrors; err != nil {
-                logger.Error(err)
-                shutdownError = err
-            }
-        }
+		// Collect shutdown errors
+		var shutdownError error
+		for i := 0; i < 2; i++ {
+			if err := <-shutdownErrors; err != nil {
+				logger.Error(err)
+				shutdownError = err
+			}
+		}
 
-        // Check if shutdown completed within timeout
-        select {
-        case <-ctx.Done():
-            if ctx.Err() == context.DeadlineExceeded {
-                logger.Error("Shutdown timed out")
-                os.Exit(1)
-            }
-        default:
-            if shutdownError != nil {
-                logger.Error("Error during shutdown")
-                os.Exit(1)
-            }
-            logger.Info("Server gracefully stopped")
-        }
-    }()
+		// Check if shutdown completed within timeout
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				logger.Error("Shutdown timed out")
+				os.Exit(1)
+			}
+		default:
+			if shutdownError != nil {
+				logger.Error("Error during shutdown")
+				os.Exit(1)
+			}
+			logger.Info("Server gracefully stopped")
+		}
+	}()
 
-    err = app.Listen(fmt.Sprintf(":%d", port))
-    if err != nil {
-        logger.Fatalf("Failed to start server: %v", err)
-    }
+	err = app.Listen(fmt.Sprintf(":%d", port))
+	if err != nil {
+		logger.Fatalf("Failed to start server: %v", err)
+	}
 }

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -14,161 +14,67 @@ import (
 	eventuc "github.com/abdisetiakawan/go-ecommerce/internal/usecase/event_uc"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
 type BootstrapConfig struct {
-	DB       *gorm.DB
-	App      *fiber.App
-	Validate *validator.Validate
-	Config   *viper.Viper
-	Jwt      *helper.JwtHelper
-	UserUUID *helper.UUIDHelper
+	DB            *gorm.DB
+	App           *fiber.App
+	Validate      *validator.Validate
+	Config        *viper.Viper
+	Jwt           *helper.JwtHelper
+	UserUUID      *helper.UUIDHelper
 	KafkaProducer *helper.KafkaProducer
-	PaymentConsumer *helper.KafkaConsumer
-	ShippingConsumer *helper.KafkaConsumer
-	OrderConsumer *helper.KafkaConsumer
 }
 
 func Bootstrap(config *BootstrapConfig) {
-    // Event
-    orderEventRepo := eventrepository.NewOrderEventRepository(config.DB)
-    orderEventUC := eventuc.NewOrderEventEvent(config.DB, orderEventRepo, config.KafkaProducer)
+	// Event
+	orderEventRepo := eventrepository.NewOrderEventRepository(config.DB)
+	orderEventUC := eventuc.NewOrderEventEvent(config.DB, orderEventRepo, config.KafkaProducer)
 
-    // Create separate consumers for each topic/operation
-    createPaymentConsumer, err := helper.NewKafkaConsumer(config.Config, "payment-create-consumer")
-    if err != nil {
-        log.Fatal(err)
-        panic(err)
-    }
-    
-    cancelPaymentConsumer, err := helper.NewKafkaConsumer(config.Config, "payment-cancel-consumer")
-    if err != nil {
-        log.Fatal(err)
-        panic(err)
-    }
-    
-    checkoutPaymentConsumer, err := helper.NewKafkaConsumer(config.Config, "payment-checkout-consumer") 
-    if err != nil {
-        log.Fatal(err)
-        panic(err)
-    }
-    
-    createShippingConsumer, err := helper.NewKafkaConsumer(config.Config, "shipping-create-consumer")
-    if err != nil {
-        log.Fatal(err)
-        panic(err)
-    }
-    
-    cancelShippingConsumer, err := helper.NewKafkaConsumer(config.Config, "shipping-cancel-consumer")
-    if err != nil {
-        log.Fatal(err)
-        panic(err)
-    }
-    
-    orderStatusConsumer, err := helper.NewKafkaConsumer(config.Config, "order-status-consumer")
-    if err != nil {
-        log.Fatal(err)
-        panic(err)
-    }
+	// Other repositories and usecases
+	userRepository := repository.NewUserRepository(config.DB)
+	profileRepository := repository.NewProfileRepository(config.DB)
+	orderRepository := repository.NewOrderRepository(config.DB)
+	productRepository := repository.NewProductRepository(config.DB)
+	storeRepository := repository.NewStoreRepository(config.DB)
+	shippingRepository := repository.NewShippingRepository(config.DB)
 
-    // Create repositories with dedicated consumers
-    createPaymentRepo := repository.NewPaymentConsumerHandler(config.DB, createPaymentConsumer)
-    cancelPaymentRepo := repository.NewPaymentConsumerHandler(config.DB, cancelPaymentConsumer)
-    checkoutPaymentRepo := repository.NewPaymentConsumerHandler(config.DB, checkoutPaymentConsumer)
-    
-    createShippingRepo := repository.NewShippingConsumerHandler(config.DB, createShippingConsumer)
-    cancelShippingRepo := repository.NewShippingConsumerHandler(config.DB, cancelShippingConsumer)
-    
-    orderStatusRepo := repository.NewOrderConsumerHandler(config.DB, orderStatusConsumer)
+	userUseCase := usecase.NewUserUseCase(config.DB, config.Validate, userRepository, config.UserUUID, config.Jwt)
+	profileUseCase := usecase.NewProfileUseCase(config.DB, config.Validate, profileRepository)
+	orderUseCase := usecase.NewOrderUseCase(config.DB, config.Validate, orderRepository, productRepository, storeRepository, config.UserUUID, orderEventUC)
+	productUseCase := usecase.NewProductUseCase(config.DB, config.Validate, productRepository, storeRepository, config.UserUUID)
+	storeUseCase := usecase.NewStoreUseCase(config.DB, config.Validate, storeRepository, config.UserUUID)
+	shippingUseCase := usecase.NewShippingUseCase(config.DB, config.Validate, shippingRepository, storeRepository, orderRepository, config.UserUUID, orderEventUC)
 
-    // Other repositories and usecases
-    userRepository := repository.NewUserRepository(config.DB)
-    profileRepository := repository.NewProfileRepository(config.DB)
-    orderRepository := repository.NewOrderRepository(config.DB)
-    productRepository := repository.NewProductRepository(config.DB)
-    storeRepository := repository.NewStoreRepository(config.DB)
-    shippingRepository := repository.NewShippingRepository(config.DB)
+	userController := http.NewUserController(userUseCase)
+	profileController := http.NewProfileController(profileUseCase)
+	orderController := http.NewOrderController(orderUseCase)
+	productController := http.NewProductController(productUseCase)
+	storeController := http.NewStoreController(storeUseCase)
+	shippingController := http.NewShippingController(shippingUseCase)
 
-    userUseCase := usecase.NewUserUseCase(config.DB, config.Validate, userRepository, config.UserUUID, config.Jwt)
-    profileUseCase := usecase.NewProfileUseCase(config.DB, config.Validate, profileRepository)
-    orderUseCase := usecase.NewOrderUseCase(config.DB, config.Validate, orderRepository, productRepository, storeRepository, config.UserUUID, orderEventUC)
-    productUseCase := usecase.NewProductUseCase(config.DB, config.Validate, productRepository, storeRepository, config.UserUUID)
-    storeUseCase := usecase.NewStoreUseCase(config.DB, config.Validate, storeRepository, config.UserUUID)
-    shippingUseCase := usecase.NewShippingUseCase(config.DB, config.Validate, shippingRepository, storeRepository, orderRepository, config.UserUUID, orderEventUC)
-    
-    userController := http.NewUserController(userUseCase)
-    profileController := http.NewProfileController(profileUseCase)
-    orderController := http.NewOrderController(orderUseCase)
-    productController := http.NewProductController(productUseCase)
-    storeController := http.NewStoreController(storeUseCase)
-    shippingController := http.NewShippingController(shippingUseCase)
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		for range ticker.C {
+			if err := orderEventUC.RetryFailedEvents(context.Background()); err != nil {
+				logrus.WithError(err).Error("Failed to retry events")
+			}
+		}
+	}()
 
-    // Start consumer goroutines with dedicated consumers
-    go func() {
-        ctx := context.Background()
-        if err := createPaymentRepo.CreatePayment(ctx); err != nil {
-            log.Error(err)
-        }
-    }()
-    
-    go func() {
-        ctx := context.Background()
-        if err := createShippingRepo.CreateShipping(ctx); err != nil {
-            log.Error(err)
-        }
-    }()
-    
-    go func() {
-        ctx := context.Background()
-        if err := cancelPaymentRepo.CancelPayment(ctx); err != nil {
-            log.Error(err)
-        }
-    }()
-    
-    go func() {
-        ctx := context.Background()
-        if err := cancelShippingRepo.CancelShipping(ctx); err != nil {
-            log.Error(err)
-        }
-    }()
-    
-    go func() {
-        ctx := context.Background()
-        if err := checkoutPaymentRepo.CheckoutPayment(ctx); err != nil {
-            log.Error(err)
-        }
-    }()
-    
-    go func() {
-        ctx := context.Background()
-        if err := orderStatusRepo.ChangeOrderStatus(ctx); err != nil {
-            log.Error(err)
-        }
-    }()
-    
-    go func() {
-        ticker := time.NewTicker(5 * time.Minute)
-        for range ticker.C {
-            if err := orderEventUC.RetryFailedEvents(context.Background()); err != nil {
-                logrus.WithError(err).Error("Failed to retry events")
-            }
-        }
-    }()
-
-    AuthMiddleware := middleware.NewAuth(config.Config)
-    routeConfig := &route.RouteConfig{
-        App: config.App,
-        ProfileController: profileController,
-        UserController: userController,
-        OrderController: orderController,
-        ProductController: productController,
-        StoreController: storeController,
-        ShippingController: shippingController,
-        AuthMiddleware: AuthMiddleware,
-    }
-    routeConfig.Setup()
+	AuthMiddleware := middleware.NewAuth(config.Config)
+	routeConfig := &route.RouteConfig{
+		App:                config.App,
+		ProfileController:  profileController,
+		UserController:     userController,
+		OrderController:    orderController,
+		ProductController:  productController,
+		StoreController:    storeController,
+		ShippingController: shippingController,
+		AuthMiddleware:     AuthMiddleware,
+	}
+	routeConfig.Setup()
 }

--- a/internal/config/consumer.go
+++ b/internal/config/consumer.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"context"
+
+	"github.com/abdisetiakawan/go-ecommerce/internal/helper"
+	"github.com/abdisetiakawan/go-ecommerce/internal/repository"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"gorm.io/gorm"
+)
+
+type ConsumerBootstrapConfig struct {
+	DB     *gorm.DB
+	Config *viper.Viper
+}
+
+func BootstrapConsumers(cfg *ConsumerBootstrapConfig) ([]*helper.KafkaConsumer, error) {
+	createPaymentConsumer, err := helper.NewKafkaConsumer(cfg.Config, "payment-create-consumer")
+	if err != nil {
+		return nil, err
+	}
+	cancelPaymentConsumer, err := helper.NewKafkaConsumer(cfg.Config, "payment-cancel-consumer")
+	if err != nil {
+		return nil, err
+	}
+	checkoutPaymentConsumer, err := helper.NewKafkaConsumer(cfg.Config, "payment-checkout-consumer")
+	if err != nil {
+		return nil, err
+	}
+	createShippingConsumer, err := helper.NewKafkaConsumer(cfg.Config, "shipping-create-consumer")
+	if err != nil {
+		return nil, err
+	}
+	cancelShippingConsumer, err := helper.NewKafkaConsumer(cfg.Config, "shipping-cancel-consumer")
+	if err != nil {
+		return nil, err
+	}
+	orderStatusConsumer, err := helper.NewKafkaConsumer(cfg.Config, "order-status-consumer")
+	if err != nil {
+		return nil, err
+	}
+
+	createPaymentRepo := repository.NewPaymentConsumerHandler(cfg.DB, createPaymentConsumer)
+	cancelPaymentRepo := repository.NewPaymentConsumerHandler(cfg.DB, cancelPaymentConsumer)
+	checkoutPaymentRepo := repository.NewPaymentConsumerHandler(cfg.DB, checkoutPaymentConsumer)
+	createShippingRepo := repository.NewShippingConsumerHandler(cfg.DB, createShippingConsumer)
+	cancelShippingRepo := repository.NewShippingConsumerHandler(cfg.DB, cancelShippingConsumer)
+	orderStatusRepo := repository.NewOrderConsumerHandler(cfg.DB, orderStatusConsumer)
+
+	go func() {
+		ctx := context.Background()
+		if err := createPaymentRepo.CreatePayment(ctx); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	go func() {
+		ctx := context.Background()
+		if err := cancelPaymentRepo.CancelPayment(ctx); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	go func() {
+		ctx := context.Background()
+		if err := checkoutPaymentRepo.CheckoutPayment(ctx); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	go func() {
+		ctx := context.Background()
+		if err := createShippingRepo.CreateShipping(ctx); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	go func() {
+		ctx := context.Background()
+		if err := cancelShippingRepo.CancelShipping(ctx); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	go func() {
+		ctx := context.Background()
+		if err := orderStatusRepo.ChangeOrderStatus(ctx); err != nil {
+			logrus.Error(err)
+		}
+	}()
+
+	return []*helper.KafkaConsumer{
+		createPaymentConsumer,
+		cancelPaymentConsumer,
+		checkoutPaymentConsumer,
+		createShippingConsumer,
+		cancelShippingConsumer,
+		orderStatusConsumer,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- decouple Kafka consumers from the API process
- add dedicated consumer bootstrap and entrypoint
- document running Kafka consumers separately

## Testing
- `go build ./...` *(fails: missing go.sum entry)*
- `go test ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_68b58f784b3c83268bf4e3fde410d48b